### PR TITLE
Fixes error thrown if administrative_area_level_2 is missing in search result

### DIFF
--- a/src/Forms/Components/GoogleAutocomplete.php
+++ b/src/Forms/Components/GoogleAutocomplete.php
@@ -108,7 +108,11 @@ class GoogleAutocomplete extends Component
                     if (str_contains($googleFieldName, '{')) {
                         $value = $this->replaceFieldPlaceholders($googleFieldName, $googleFields, $googleFieldValue);
                     } else {
-                        $value = $googleFields[$googleFieldName][$googleFieldValue] ?: '';
+                        // bc: Fixes issue with Carson City, NV.  No administrative_area_level_2 provided in search result.
+                        $value = '';
+                        if (isset($googleFields[$googleFieldName][$googleFieldValue])) {
+                            $value = $googleFields[$googleFieldName][$googleFieldValue] ?: '';
+                        }
                     }
 
                     $set($field->getName(), $value);


### PR DESCRIPTION
Fixes issue with Carson City, NV.  If no administrative_area_level_2 data is provided in the search result, this throws an error.