### PR TITLE
Call afterStateUpdated hook on value change

### DIFF
--- a/src/Forms/Components/GoogleAutocomplete.php
+++ b/src/Forms/Components/GoogleAutocomplete.php
@@ -116,6 +116,7 @@ class GoogleAutocomplete extends Component
                     }
 
                     $set($field->getName(), $value);
+                    $field->callAfterStateUpdated();
                 }
             });
 


### PR DESCRIPTION
Actually we can't use afterStateUpdated hook on our custom "withFields" inputs.
With this change we are now able to do things such as:

```
TextInput::make('latitude')
                        ->label(__('filament/resources/address.form.latitude'))
                        ->numeric()
                        ->readOnly()
                        ->extraInputAttributes([
                            'data-google-field' => 'latitude',
                        ])
                        ->afterStateHydrated(function ($state, callable $get, callable $set) {
                            $set('location', [
                                'lat' => floatVal($state),
                                'lng' => floatVal($get('longitude')),
                            ]);
                        }),
```
To update another field for example:
![CleanShot 2024-12-28 at 12 40 26@2x](https://github.com/user-attachments/assets/d54116ae-2d22-427e-9a93-1c445b8c44b0)
