### PR TITLE
Reset autocomplete field when performing a new search

### DIFF
--- a/src/Forms/Components/GoogleAutocomplete.php
+++ b/src/Forms/Components/GoogleAutocomplete.php
@@ -79,7 +79,8 @@ class GoogleAutocomplete extends Component
             ->searchable()
             ->hint(new HtmlString(Blade::render('<x-filament::loading-indicator class="h5 w-5" wire:loading wire:target="data.google_autocomplete_'.$this->getAutocompleteName().'" />')))
             ->columnSpan($this->getAutocompleteFieldColumnSpan())
-            ->getSearchResultsUsing(function (string $search): array {
+            ->getSearchResultsUsing(function (string $search, Set $set): array {
+                $set($this->getAutocompleteName(), null);
                 $response = $this->getPlaceAutocomplete($search);
 
                 $result = $response->collect();


### PR DESCRIPTION
### Description
This PR fixes an issue where conducting multiple searches in the Google Autocomplete field causes previous search results to appear in subsequent searches. The problem occurs because the place_id of the first selected option is like kept in memory and appears in the list of options during a new search.
The fix is simple : we reset the autocomplete field value to null each time we retrieve search options, ensuring that no stale data persists between searches.

### Changes

Added `$set($this->getAutocompleteName(), null);` in the getSearchResultsUsing method to clear the field value before fetching new options

### Related Issue
Fixes #30  - "Strange option appears when conducting multiple searches"