### PR TITLE
Update GoogleAutocomplete field processing to handle Hidden components

### DIFF
--- a/src/Forms/Components/GoogleAutocomplete.php
+++ b/src/Forms/Components/GoogleAutocomplete.php
@@ -101,7 +101,10 @@ class GoogleAutocomplete extends Component
                 $googleFields = $this->getFormattedApiResults($data);
 
                 foreach ($this->getWithFields() as $field) {
-                    $fieldExtraAttributes = $field->getExtraInputAttributes();
+                    // Check if the field is a Hidden component or has getExtraInputAttributes method
+                    $fieldExtraAttributes = $field instanceof Forms\Components\Hidden
+                        ? $field->getExtraAttributes()
+                        : $field->getExtraInputAttributes();
 
                     $googleFieldName = count($fieldExtraAttributes) > 0 && isset($fieldExtraAttributes['data-google-field']) ? $fieldExtraAttributes['data-google-field'] : $field->getName();
 


### PR DESCRIPTION
Hi @tappnetwork 👋

I've added support for using Filament hidden fields with the GoogleAutocomplete field.

Previously, the getExtraInputAttributes method was used to inject Google address data, which works only with visible input fields. To enable support for hidden fields, this PR now uses getExtraAttributes for Hidden inputs, making it possible to automatically populate hidden fields with values returned from the Google API.

This is especially helpful for use cases where certain address components (like short_names) should be stored without being directly editable by the user.

Let me know if you have any feedback or would like any changes made.
Thanks again for your great work on this package! 🙌