### PR TITLE
Laravel Filament 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
         "filament/filament": "^5.0|^4.0",
-        "illuminate/contracts": "^10.0||^11.0||^12.0",
+        "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",
         "skagarwal/google-places-api": "^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Fix Laravel 13 compatibility

This PR updates the `illuminate/contracts` constraint to include `^13.0`, allowing the package to be installed in Laravel 13 applications.

Although the package already supports `filament/filament ^5.0`, the current constraint on `illuminate/contracts` (`^10 || ^11 || ^12`) prevents Composer from resolving dependencies when using Laravel 13, since `laravel/framework` replaces `illuminate/contracts` with version 13.

### Changes

* Updated:

  * `illuminate/contracts` → `^10 || ^11 || ^12 || ^13`

### Notes

This change does not introduce any breaking changes and simply relaxes the version constraint to support the latest Laravel release.

Tested locally with Laravel 13 + Filament 5.
