### PR TITLE
Drop PHP 8.2 support, add PHP 8.5

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          php-version: "8.5"
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.3, 8.2]
+        php: [8.3, 8.4, 8.5]
         laravel: ['12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
@@ -27,9 +27,6 @@ jobs:
             testbench: ^10.0
           - laravel: 13.*
             testbench: ^11.0
-        exclude:
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
         "filament/filament": "^4.0|^5.0",
         "illuminate/contracts": "^10.0||^11.0||^12.0||^13.0",


### PR DESCRIPTION
## Summary

- Drops PHP 8.2 from the supported version matrix
- Adds PHP 8.5 to the test matrix (now 8.3, 8.4, 8.5)
- Updates `composer.json` minimum PHP requirement from `^8.2` to `^8.3`
- Updates PHPStan workflow to run on PHP 8.5
- Removes the Laravel 13 + PHP 8.2 exclusion rule (no longer needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)